### PR TITLE
Planning Directory Sync - Link update

### DIFF
--- a/docs/preperation.md
+++ b/docs/preperation.md
@@ -73,7 +73,7 @@ See the following support article for information on the attributes that can be 
 
 ### Active Directory Attribute Values
 
-IdFix checks several Active Directory attributes for the types of errors included in the [Planning Directory Synchronization – Active Directory Cleanup](http://technet.microsoft.com/en-us/library/hh852469.aspx).
+IdFix checks several Active Directory attributes for the types of errors included in the [Planning Directory Synchronization – Active Directory Cleanup](https://docs.microsoft.com/en-us/microsoft-365/enterprise/prepare-for-directory-synchronization?view=o365-worldwide).
 
 ## Dedicated
 


### PR DESCRIPTION
Hi, 

I noticed that the Planning Directory Synchronisation - Active Directory Cleanup link is no longer pointing to a valid URL (http://technet.microsoft.com/en-us/library/hh852469.aspx) so I've submitted a pull request to the page I believe you are trying to signpost people to (https://docs.microsoft.com/en-us/microsoft-365/enterprise/prepare-for-directory-synchronization?view=o365-worldwide). 

Hope this is okay?

Many thanks
James.

#### Category
- [ ] Bug fix
- [ ] New feature
- [ ] New sample
- [x] Documentation update

#### Related Issues

fixes #X, mentioned in #Y

#### What's in this Pull Request?

*Please describe the changes in this PR. Simple description or details around bugs which are being fixed.*

#### Guidance
*You can delete this section when you are submitting the pull request.* 
* Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.
* Please ensure you have updated any associated docs files based on your code changes
