### PR TITLE
Fixed bug in proxyAddress duplicate detection when values differ only…

### DIFF
--- a/src/IdFix/DuplicateStore.cs
+++ b/src/IdFix/DuplicateStore.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.DirectoryServices.Protocols;
+using System.Linq;
 
 namespace IdFix
 {
@@ -14,14 +17,31 @@ namespace IdFix
         private static Dictionary<string, List<string>> _lookup;
 
         /// <summary>
+        /// Key = attribute name
+        /// Value = Dictionary of the attribute values and the first LDAP entry with that value
+        /// </summary>
+        private static Dictionary<string, Dictionary<string, SearchResultEntry>> _originalEntryLookup;
+
+        /// <summary>
         /// Determines if a given value is a duplicate for a given attribute
         /// </summary>
         /// <param name="attributeName">Name of the attribute whose value we are checking</param>
-        /// <param name="attributeValue">Vlaue of the attribute we expect to be unique</param>
+        /// <param name="attributeValue">Value of the attribute we expect to be unique</param>
+        /// <param name="entry">LDAP entry being checked</param>
         /// <returns>True if the value is a duplicate, false otherwise</returns>
-        public static bool IsDuplicate(string attributeName, string attributeValue)
+        public static bool IsDuplicate(string attributeName, string attributeValue, SearchResultEntry entry)
         {
-            if (DuplicateStore._lookup.ContainsKey(attributeName) && DuplicateStore._lookup[attributeName].Contains(attributeValue))
+            if (!DuplicateStore._originalEntryLookup.ContainsKey(attributeName))
+            {
+                DuplicateStore._originalEntryLookup.Add(attributeName, new Dictionary<string, SearchResultEntry>());
+            }
+
+            if (DuplicateStore._originalEntryLookup.ContainsKey(attributeName) && !DuplicateStore._originalEntryLookup[attributeName].Keys.Contains(attributeValue, StringComparer.InvariantCultureIgnoreCase))
+            {
+                DuplicateStore._originalEntryLookup[attributeName].Add(attributeValue, entry);
+            }
+
+            if (DuplicateStore._lookup.ContainsKey(attributeName) && DuplicateStore._lookup[attributeName].Contains(attributeValue, StringComparer.InvariantCultureIgnoreCase))
             {
                 return true;
             }
@@ -41,6 +61,20 @@ namespace IdFix
         public static void Reset()
         {
             DuplicateStore._lookup = new Dictionary<string, List<string>>();
+            DuplicateStore._originalEntryLookup = new Dictionary<string, Dictionary<string, SearchResultEntry>>();
+        }
+
+        /// <summary>
+        /// Gets the original (first) LDAP entry with the value matching the attribute
+        /// </summary>
+        /// <param name="attributeName">The name of the attribute</param>
+        /// <param name="attributeValue">The attribute value</param>
+        /// <returns>The original (first) LDAP entry</returns>
+        public static SearchResultEntry GetOriginalSearchResultEntry(string attributeName, string attributeValue)
+        {
+            var dic = DuplicateStore._originalEntryLookup[attributeName];
+            var key = dic.Keys.First(k => string.Compare(k, attributeValue, true) == 0);
+            return dic[key];
         }
     }
 }

--- a/src/IdFix/Rules/Shared/NoDuplicatesRule.cs
+++ b/src/IdFix/Rules/Shared/NoDuplicatesRule.cs
@@ -29,7 +29,7 @@ namespace IdFix.Rules.Shared
         public override RuleResult Execute(ComposedRule parent, SearchResultEntry entry, string attributeValue)
         {
             // record in memory the entry details with a list of the attributes that end up needing to be checked
-            if (DuplicateStore.IsDuplicate(parent.AttributeName, attributeValue))
+            if (DuplicateStore.IsDuplicate(parent.AttributeName, attributeValue, entry))
             {
                 // we now need to execute some complicated logic from the original application depending
                 // settings, etc. this isn't pretty but it follows the original for now
@@ -47,7 +47,7 @@ namespace IdFix.Rules.Shared
                             {
                                 if (entry.Attributes.Contains(StringLiterals.MailNickName))
                                 {
-                                    if (attributeValue.Substring(0, 5) == "SMTP:")
+                                    if (attributeValue.ToLowerInvariant().Substring(0, 5) == "smtp:")
                                     {
                                         actionType = ActionType.Complete;
                                     }


### PR DESCRIPTION
… in casing.  Now including all LDAP entries that share duplicate attribute values.

#### Category
- [X] Bug fix
- [ ] New feature
- [ ] New sample
- [ ] Documentation update

#### Related Issues

fixes #29 and #40 

#### What's in this Pull Request?

Fixes bug in proxyAddress duplicate detection when values are different only in casing. 
Now displaying all LDAP entries with duplicate values.
